### PR TITLE
bump versions for cocos2d-mono 2.5.6

### DIFF
--- a/Basic Samples/Android/Cocos2dMonoGame.Android/Cocos2dMonoGame.Android.csproj
+++ b/Basic Samples/Android/Cocos2dMonoGame.Android/Cocos2dMonoGame.Android.csproj
@@ -52,7 +52,7 @@
     <MonoGameContentReference Include="Content\Content.mgcb" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/AppGame/AppGame.Android/AppGame.Android.csproj
+++ b/Basic Samples/AppGame/AppGame.Android/AppGame.Android.csproj
@@ -52,7 +52,7 @@
     <MonoGameContentReference Include="Content\Content.mgcb" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/AppGame/AppGame.iOS.CoreApp/AppGame.iOS.CoreApp.csproj
+++ b/Basic Samples/AppGame/AppGame.iOS.CoreApp/AppGame.iOS.CoreApp.csproj
@@ -19,7 +19,7 @@
     </CollectBundleResourcesDependsOn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/AppGame/AppGame.iOS/AppGame.iOS.csproj
+++ b/Basic Samples/AppGame/AppGame.iOS/AppGame.iOS.csproj
@@ -148,7 +148,7 @@
     <BundleResource Include="Content\sprites\ui.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/AudioSample/AudioSample.Windows/AudioSample.Windows.csproj
+++ b/Basic Samples/AudioSample/AudioSample.Windows/AudioSample.Windows.csproj
@@ -17,7 +17,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/Box2dSample/Box2dSample.Windows/Box2dSample.Windows.csproj
+++ b/Basic Samples/Box2dSample/Box2dSample.Windows/Box2dSample.Windows.csproj
@@ -17,7 +17,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/Core.Android/Cocos2dMonoGame.Core.Android/Cocos2dMonoGame.Core.Android.csproj
+++ b/Basic Samples/Core.Android/Cocos2dMonoGame.Core.Android/Cocos2dMonoGame.Core.Android.csproj
@@ -42,7 +42,7 @@
     <AndroidResource Include="Resources\Values\Strings.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Core.Android" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Core.Android" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/Basic Samples/Core.DesktopGL/Cocos2DMonoGame.Core.DesktopGL/Cocos2DMonoGame.Core.DesktopGL.csproj
+++ b/Basic Samples/Core.DesktopGL/Cocos2DMonoGame.Core.DesktopGL/Cocos2DMonoGame.Core.DesktopGL.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -26,7 +26,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Core.DesktopGL" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Core.DesktopGL" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/Basic Samples/Core.Linux/Cocos2DMonoGame.Core.Linux/Cocos2DMonoGame.Core.Linux.csproj
+++ b/Basic Samples/Core.Linux/Cocos2DMonoGame.Core.Linux/Cocos2DMonoGame.Core.Linux.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -26,7 +26,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Core.Linux" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Core.Linux" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/Basic Samples/Core.Windows/Cocos2dMonoGame.Core.Windows/Cocos2DMonoGame.Core.Windows.csproj
+++ b/Basic Samples/Core.Windows/Cocos2dMonoGame.Core.Windows/Cocos2DMonoGame.Core.Windows.csproj
@@ -14,7 +14,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Core.Windows" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Core.Windows" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/Basic Samples/Core.iOS/Cocos2dMonoGame.Core.iOS/Cocos2DMonoGame.Core.iOS.csproj
+++ b/Basic Samples/Core.iOS/Cocos2dMonoGame.Core.iOS/Cocos2DMonoGame.Core.iOS.csproj
@@ -114,7 +114,7 @@
     <BundleResource Include="GameThumbnail.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Core.iOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Core.iOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/Basic Samples/Core.macOS/Cocos2DMonoGame.Core.macOS/Cocos2DMonoGame.Core.macOS.csproj
+++ b/Basic Samples/Core.macOS/Cocos2DMonoGame.Core.macOS/Cocos2DMonoGame.Core.macOS.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -26,7 +26,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Core.macOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Core.macOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/Basic Samples/DesktopGL/Cocos2DMonoGame.DesktopGL/Cocos2DMonoGame.DesktopGL.csproj
+++ b/Basic Samples/DesktopGL/Cocos2DMonoGame.DesktopGL/Cocos2DMonoGame.DesktopGL.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -32,7 +32,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/Linux/Cocos2DMonoGame.Linux/Cocos2DMonoGame.Linux.csproj
+++ b/Basic Samples/Linux/Cocos2DMonoGame.Linux/Cocos2DMonoGame.Linux.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -32,7 +32,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/Windows/Cocos2dMonoGame.Windows/Cocos2dMonoGame.Windows.csproj
+++ b/Basic Samples/Windows/Cocos2dMonoGame.Windows/Cocos2dMonoGame.Windows.csproj
@@ -17,7 +17,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/iOS/Cocos2dMonoGame.iOS/Cocos2dMonoGame.iOS.csproj
+++ b/Basic Samples/iOS/Cocos2dMonoGame.iOS/Cocos2dMonoGame.iOS.csproj
@@ -119,7 +119,7 @@
     <Content Include=".config\dotnet-tools.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Basic Samples/macOS/Cocos2DMonoGame.macOS/Cocos2DMonoGame.macOS.csproj
+++ b/Basic Samples/macOS/Cocos2DMonoGame.macOS/Cocos2DMonoGame.macOS.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -32,7 +32,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AirHockey/AirHiockey.iOS/AirHiockey.iOS.csproj
+++ b/Full Samples/AirHockey/AirHiockey.iOS/AirHiockey.iOS.csproj
@@ -126,7 +126,7 @@
     <Content Include=".config\dotnet-tools.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AirHockey/AirHockey.Android/AirHockey.Android.csproj
+++ b/Full Samples/AirHockey/AirHockey.Android/AirHockey.Android.csproj
@@ -50,7 +50,7 @@
     </MonoGameContentReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AirHockey/AirHockey.DesktopGL/AirHockey.DesktopGL.csproj
+++ b/Full Samples/AirHockey/AirHockey.DesktopGL/AirHockey.DesktopGL.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AirHockey/AirHockey.Linux/AirHockey.Linux.csproj
+++ b/Full Samples/AirHockey/AirHockey.Linux/AirHockey.Linux.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AirHockey/AirHockey.Windows/AirHockey.Windows.csproj
+++ b/Full Samples/AirHockey/AirHockey.Windows/AirHockey.Windows.csproj
@@ -17,7 +17,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AirHockey/AirHockey.macOS/AirHockey.macOS.csproj
+++ b/Full Samples/AirHockey/AirHockey.macOS/AirHockey.macOS.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AngryNinjas/AngryNinjas.Android/AngryNinjas.Android.csproj
+++ b/Full Samples/AngryNinjas/AngryNinjas.Android/AngryNinjas.Android.csproj
@@ -57,7 +57,7 @@
 		</MonoGameContentReference>
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AngryNinjas/AngryNinjas.DesktopGL/AngryNinjas.DesktopGL.csproj
+++ b/Full Samples/AngryNinjas/AngryNinjas.DesktopGL/AngryNinjas.DesktopGL.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AngryNinjas/AngryNinjas.Linux/AngryNinjas.Linux.csproj
+++ b/Full Samples/AngryNinjas/AngryNinjas.Linux/AngryNinjas.Linux.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AngryNinjas/AngryNinjas.Windows/AngryNinjas.Windows.csproj
+++ b/Full Samples/AngryNinjas/AngryNinjas.Windows/AngryNinjas.Windows.csproj
@@ -17,7 +17,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AngryNinjas/AngryNinjas.iOS/AngryNinjas.iOS.csproj
+++ b/Full Samples/AngryNinjas/AngryNinjas.iOS/AngryNinjas.iOS.csproj
@@ -126,7 +126,7 @@
     <Content Include=".config\dotnet-tools.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.iOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.iOS" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/AngryNinjas/AngryNinjas.macOS/AngryNinjas.macOS.csproj
+++ b/Full Samples/AngryNinjas/AngryNinjas.macOS/AngryNinjas.macOS.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/SkyDefense/SkyDefense.Android/SkyDefense.Android.csproj
+++ b/Full Samples/SkyDefense/SkyDefense.Android/SkyDefense.Android.csproj
@@ -50,7 +50,7 @@
 		</MonoGameContentReference>
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/SkyDefense/SkyDefense.DesktopGL/SkyDefense.DesktopGL.csproj
+++ b/Full Samples/SkyDefense/SkyDefense.DesktopGL/SkyDefense.DesktopGL.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/SkyDefense/SkyDefense.Linux/SkyDefense.Linux.csproj
+++ b/Full Samples/SkyDefense/SkyDefense.Linux/SkyDefense.Linux.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/SkyDefense/SkyDefense.Windows/SkyDefense.Windows.csproj
+++ b/Full Samples/SkyDefense/SkyDefense.Windows/SkyDefense.Windows.csproj
@@ -17,7 +17,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Windows" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/SkyDefense/SkyDefense.macOS/SkyDefense.macOS.csproj
+++ b/Full Samples/SkyDefense/SkyDefense.macOS/SkyDefense.macOS.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -37,7 +37,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>

--- a/Full Samples/TetrisGame/TetrisGame.Android/TetrisGame.Android.csproj
+++ b/Full Samples/TetrisGame/TetrisGame.Android/TetrisGame.Android.csproj
@@ -51,7 +51,7 @@
     <MonoGameContentReference Include="Content\Content.mgcb" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Android" Version="2.5.6" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Framework.Android" Version="$(MonoGameVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Full Samples/TetrisGame/TetrisGame.DesktopGL/TetrisGame.DesktopGL.csproj
+++ b/Full Samples/TetrisGame/TetrisGame.DesktopGL/TetrisGame.DesktopGL.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -29,7 +29,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Full Samples/TetrisGame/TetrisGame.Linux/TetrisGame.Linux.csproj
+++ b/Full Samples/TetrisGame/TetrisGame.Linux/TetrisGame.Linux.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -29,7 +29,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.Linux" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Full Samples/TetrisGame/TetrisGame.macOS/TetrisGame.macOS.csproj
+++ b/Full Samples/TetrisGame/TetrisGame.macOS/TetrisGame.macOS.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -29,7 +29,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.macOS" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Tutorial Samples/Platformer/Checkpoints/Part 1/Platformer/Platformer.csproj
+++ b/Tutorial Samples/Platformer/Checkpoints/Part 1/Platformer/Platformer.csproj
@@ -6,7 +6,7 @@
     <TieredCompilation>false</TieredCompilation>
     <PackAsTool>false</PackAsTool>
     <PackageId>Cocos2DMono.DesktopGL</PackageId>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
     <Authors>Cocos2D-Mono Team</Authors>
     <Description>A template project for building DesktopGL games using Cocos2D-Mono.</Description>
     <PackageType>Template</PackageType>

--- a/Tutorial Samples/Platformer/Checkpoints/Part 2/Platformer/Platformer.csproj
+++ b/Tutorial Samples/Platformer/Checkpoints/Part 2/Platformer/Platformer.csproj
@@ -6,7 +6,7 @@
     <TieredCompilation>false</TieredCompilation>
     <PackAsTool>false</PackAsTool>
     <PackageId>Cocos2DMono.DesktopGL</PackageId>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
     <Authors>Cocos2D-Mono Team</Authors>
     <Description>A template project for building DesktopGL games using Cocos2D-Mono.</Description>
     <PackageType>Template</PackageType>

--- a/Tutorial Samples/Platformer/Checkpoints/Part 3/Platformer/Platformer.csproj
+++ b/Tutorial Samples/Platformer/Checkpoints/Part 3/Platformer/Platformer.csproj
@@ -6,7 +6,7 @@
     <TieredCompilation>false</TieredCompilation>
     <PackAsTool>false</PackAsTool>
     <PackageId>Cocos2DMono.DesktopGL</PackageId>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
     <Authors>Cocos2D-Mono Team</Authors>
     <Description>A template project for building DesktopGL games using Cocos2D-Mono.</Description>
     <PackageType>Template</PackageType>

--- a/Tutorial Samples/Platformer/Checkpoints/Part 4/Platformer/Platformer.csproj
+++ b/Tutorial Samples/Platformer/Checkpoints/Part 4/Platformer/Platformer.csproj
@@ -6,7 +6,7 @@
     <TieredCompilation>false</TieredCompilation>
     <PackAsTool>false</PackAsTool>
     <PackageId>Cocos2DMono.DesktopGL</PackageId>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
     <Authors>Cocos2D-Mono Team</Authors>
     <Description>A template project for building DesktopGL games using Cocos2D-Mono.</Description>
     <PackageType>Template</PackageType>

--- a/Tutorial Samples/Platformer/Checkpoints/Part 5/Platformer/Platformer.csproj
+++ b/Tutorial Samples/Platformer/Checkpoints/Part 5/Platformer/Platformer.csproj
@@ -6,7 +6,7 @@
     <TieredCompilation>false</TieredCompilation>
     <PackAsTool>false</PackAsTool>
     <PackageId>Cocos2DMono.DesktopGL</PackageId>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
     <Authors>Cocos2D-Mono Team</Authors>
     <Description>A template project for building DesktopGL games using Cocos2D-Mono.</Description>
     <PackageType>Template</PackageType>

--- a/Tutorial Samples/Platformer/Final/Platformer/Platformer.csproj
+++ b/Tutorial Samples/Platformer/Final/Platformer/Platformer.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <Version>2.5.5</Version>
+    <Version>2.5.6</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;WINDOWS</DefineConstants>
@@ -32,7 +32,7 @@
     <TrimmerRootAssembly Include="Microsoft.Xna.Framework.Content.ContentTypeReader" Visible="false" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.5" />
+    <PackageReference Include="Cocos2D-Mono.DesktopGL" Version="2.5.6" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="$(MonoGameVersion)" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="$(MonoGameVersion)" />
   </ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Cocos2D-Mono framework to version 2.5.6 across all sample and tutorial projects, supporting Android, iOS, Windows, Linux, and macOS platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->